### PR TITLE
Fix "TypeError: null is not an object"

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,11 +56,11 @@ function parsePodcastDict(dict) {
   // title: "《赖世雄美语音标》讲解音频"
   // uuid: "55C5D14D-0CCC-4B79-AEA9-17CA3609F522"
   var o = {};
-  for (var i=0;i<dict.childNodes.length-1;i+=4) {
-    var k = dict.childNodes[i+1];
-    k = k.firstChild.nodeValue;
-    var v = dict.childNodes[i+3];
-    v = v.firstChild.nodeValue;
+  for (var i=0;i<dict.children.length-1;i=i+=2) {
+    var k = dict.children[i];
+    k = k.textContent;
+    var v = dict.children[i+1];
+    v = v.textContent;
     o[k] = v;
     // console.log(i, dict.childNodes[i], k ,v);
     if (k==='title') {

--- a/app.js
+++ b/app.js
@@ -1,5 +1,10 @@
 "use strict";
 
+function log(text) {
+  let info = document.getElementById('info');
+  info.append(text + '\n');
+}
+
 window.onload = function () {
   let fileInput = document.getElementById('plistFile');
   fileInput.addEventListener('change', function (e) {
@@ -11,8 +16,7 @@ window.onload = function () {
         parsePlist(reader.result);
       } catch(e)  {
         console.error(e);
-        let warn = document.getElementById('warn');
-        warn.innerText = e;
+        log("🛑 " + e);
       }
     };
     reader.readAsText(file);
@@ -41,13 +45,17 @@ function parsePlist(body) {
         for(var m=0;m<podcasts_array.childNodes.length; m++ ) {
           var current = podcasts_array.childNodes[m];
           if (current.nodeName === 'dict') {
-            ret.push(parsePodcastDict(current));
+            let podcast = parsePodcastDict(current)
+            if (podcast) {
+              ret.push(parsePodcastDict(current));
+            }
           }
         }
       }
     }
   }
   download(ret);
+  log(`✅ Exported ${ret.length} podcasts`);
 }
 
 function parsePodcastDict(dict) {
@@ -68,6 +76,10 @@ function parsePodcastDict(dict) {
     } else if (k==='feedUrl') {
       o.feedUrl = v.replace( /&/g, '&amp;' );
     }
+  }
+  if (!o.feedUrl) {
+    log(`⚠️ Exclude podcast "${o.title}" due to missing feed url`)
+    return null;
   }
   return o;
 }

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
       .upload {
           margin: 30px 0 20px 0;
       }
+
+      #info {
+        white-space: pre-line;
+      }
     </style>
     <title>Podcasts exporter for macOS Catalina</title>
   </head>
@@ -29,7 +33,7 @@
         <label class="custom-file-label" for="plistFile">Choose plist file:</label>
         <input type="file" class="custom-file-input" id="plistFile" accept=".plist">
       </div>
-      <div id="warn"></div>
+      <div id="info"></div>
       <a id="download" download="Podcasts.opml" style="display:none"></a>
       <p>If you have any questions or suggestions, welcome to <a href="https://github.com/jiacai2050/podcasts-opml-exporter/issues">open an issue.</a> 🛠</p>
     </div>


### PR DESCRIPTION
Suggestion for fixing #4 when a podcast is missing a feed url. This fix will exclude podcasts that is missing a feed url and display the broken podcasts entries for the user.

Also changed so we iterate over `children` instead of `childNodes` on the podcast dict, then we don't have to skip the extra text nodes that the parser includes due to `\n`.

## Screenshot with example file from #4:
![Screen Shot 2022-10-25 at 23 27 52](https://user-images.githubusercontent.com/18744409/197885464-1448e8f3-5dd1-47ac-9f5a-46d15ad8503a.png)

Thanks for this great tool! It worked great for me on MacOS Big Sur as well. 

Feel free to make changes or suggest another solution.